### PR TITLE
Use multivariate polynomial rings throughout

### DIFF
--- a/cutgeneratingfunctionology/igp/parametric.sage
+++ b/cutgeneratingfunctionology/igp/parametric.sage
@@ -2926,6 +2926,12 @@ def find_point_flip_ineq_heuristic(current_var_value, ineq, ineqs, flip_ineq_ste
         sage: pt = find_point_flip_ineq_heuristic(current_var_value, ineq, ineqs, flip_ineq_step); # got pt (19419/17801, 11629/24865)
         sage: all(l(pt) < 0 for l in ineqs) and ineq(pt)>0
         True
+
+    Bug examle from positive definite matrix [a, b; b, 1/4], where ineq is very negative at the test point. Make big moves first, then small moves::
+        sage: P.<a,b>=QQ[]; current_var_value = (5, 4); ineq = -4*b^2 + a; ineqs = [-a]; flip_ineq_step=1/100
+        sage: pt = find_point_flip_ineq_heuristic(current_var_value, ineq, ineqs, flip_ineq_step); # got pt (30943/6018, 17803/15716)
+        sage: all(l(pt) < 0 for l in ineqs) and ineq(pt)>0
+        True
     """
     # heuristic method.
     ineq_gradient = gradient(ineq)

--- a/cutgeneratingfunctionology/igp/parametric.sage
+++ b/cutgeneratingfunctionology/igp/parametric.sage
@@ -230,8 +230,8 @@ class ParametricRealField(Field):
             else:
                 raise ValueError("must provide one of names, sym_ring, or bsa")
         if sym_ring is None:
-            #sym_ring = PolynomialRing(base_ring, names, implementation='generic')
-            sym_ring = PolynomialRing(base_ring, names)
+            #sym_ring = PolynomialRing(base_ring, names, len(names), implementation='generic')
+            sym_ring = PolynomialRing(base_ring, names, len(names))
         self._factor_bsa = BasicSemialgebraicSet_eq_lt_le_sets(poly_ring=sym_ring)
         self._sym_field = sym_ring.fraction_field()
         if values is None:
@@ -1199,7 +1199,7 @@ def find_polynomial_map(eqs=[], poly_ring=None):
                     if i != ii:
                         eqs[ii] = eqs[ii].subs({v:v_mapped_to})
                 break
-    #P = PolynomialRing(poly_ring.base_ring(), list(independent_variables))
+    #P = PolynomialRing(poly_ring.base_ring(), list(independent_variables), len(...))
     #return [P(p) for p in polynomial_map]
     # didn't take sub-polynomialring to make the trick ineq orthogonal to eliminated variables work.
     return polynomial_map
@@ -1307,7 +1307,7 @@ class SemialgebraicComplexComponent(SageObject):    # FIXME: Rename this to be m
 
     def __init__(self, K, region_type, bddbsa=None, polynomial_map=None):
         self.var_name = list(K.variable_names()) #same as [ str(g) for g in K._bsa.poly_ring().gens() ]
-        poly_ring = PolynomialRing(QQ, self.var_name)  #same as K._bsa.poly_ring()
+        poly_ring = PolynomialRing(QQ, self.var_name, len(self.var_name))  #same as K._bsa.poly_ring()
         self.var_value = K._values # var_value was input of __init__. It doesn't seem necessary.
         self.region_type = region_type
         #Default bddbsa=None and polynomial_map=None are just for the convenience of doctests.
@@ -1726,7 +1726,7 @@ class ProofCell(SemialgebraicComplexComponent, Classcall):
         if 'merge' in args_set:
             test_point['merge'] = False
         #if bddbsa is None:
-        #    bddbsa =  BasicSemialgebraicSet_eq_lt_le_sets(poly_ring=PolynomialRing(QQ, var_name)) # class doesn't matter, just to record the constraints on K._bsa
+        #    bddbsa =  BasicSemialgebraicSet_eq_lt_le_sets(poly_ring=PolynomialRing(QQ, var_name, len(var_name)) # class doesn't matter, just to record the constraints on K._bsa
         #The code seems to still work after commenting out the following.
         #K.add_initial_space_dim() #so that the parameters var_name are the first ones in the monomial list. Needed for ppl variable elimination, otherwise ineqs are not orthogonal to eliminated variables. FIXME: Get rid of this requirement. Also needed for Mccormicks?
         #assert (K.gens() in bddbsa) # record boundary constraints. # Move to __init__
@@ -1925,7 +1925,7 @@ class SemialgebraicComplex(SageObject):
         self.find_region_type = find_region_type
         self.default_var_bound = default_var_bound
         if bddbsa is None:   #HAS BUG: r = regions[31]; theta = thetas[16]; cpl_complex = cpl_fill_region_given_theta(r, theta); self.bddbsa = BasicSemialgebraicSet_veronese(BasicSemialgebraicSet_polyhedral_ppl_NNC_Polyhedron(Constraint_System {x0+6*x1-1==0, -x0+1>0, 2*x0-1>0}), polynomial_map=[f, z]); self.bddbsa.polynomial_map() is [f, z]; self.bddbsa.ambient_dim() is 1.
-            poly_ring = PolynomialRing(QQ, var_name)
+            poly_ring = PolynomialRing(QQ, var_name, self.d)
             self.bddbsa = BasicSemialgebraicSet_veronese(poly_ring=poly_ring)
         else:
             self.bddbsa = bddbsa
@@ -1934,7 +1934,7 @@ class SemialgebraicComplex(SageObject):
             if eqs:
                 #Only useful for treating careless input with low dim bddbsa provided but not polynomial_map. # should not happen in cpl because we pass r.polynomal_map to cpl_complex.
                 #import pdb; pdb.set_trace()
-                self.polynomial_map = find_polynomial_map(eqs, poly_ring=PolynomialRing(QQ, var_name))
+                self.polynomial_map = find_polynomial_map(eqs, poly_ring=PolynomialRing(QQ, var_name, self.d))
             else:
                 self.polynomial_map = list(self.bddbsa.poly_ring().gens())
         else:

--- a/cutgeneratingfunctionology/igp/parametric.sage
+++ b/cutgeneratingfunctionology/igp/parametric.sage
@@ -82,7 +82,7 @@ class ParametricRealField(Field):
         set()
         sage: R = f._sym.parent().ring()
         sage: sorted([ p for p in K.get_lt() if p in R ])   # filter out the rational function 1/(f^2 - f), which is normalized differently starting Sage 8.4b2
-        [-2*f, -2*f + 1, -f - 1, -f, f - 2, f - 1, 2*f - 2]
+        [-2*f, -2*f + 1, -f, -f - 1, f - 2, f - 1, 2*f - 2]
         sage: K.get_eq_factor()
         set()
         sage: K.get_lt_factor()
@@ -318,7 +318,7 @@ class ParametricRealField(Field):
             sage: sqrt2, = nice_field_values([sqrt(2)])
             sage: K.<f> = ParametricRealField([0], base_ring=sqrt2.parent())
             sage: f + sqrt2
-            (f + 1.414213562373095?)~
+            (f + (a))~
 
         This currently does not work for Sage's built-in embedded number field elements...
         """

--- a/cutgeneratingfunctionology/igp/parametric.sage
+++ b/cutgeneratingfunctionology/igp/parametric.sage
@@ -2920,12 +2920,18 @@ def find_point_flip_ineq_heuristic(current_var_value, ineq, ineqs, flip_ineq_ste
         sage: pt = find_point_flip_ineq_heuristic(current_var_value, ineq, ineqs, flip_ineq_step) # got pt (3738/13883, 7795/67523)
         sage: all(l(pt) < 0 for l in ineqs) and ineq(pt)>0
         True
+
+    Bug example from positive definite matrix [a, b; b, 1/4]::
+        sage: P.<a,b>=QQ[]; current_var_value = (1, 1); ineq = -4*b^2 + a; ineqs = [-a]; flip_ineq_step=1/3
+        sage: pt = find_point_flip_ineq_heuristic(current_var_value, ineq, ineqs, flip_ineq_step); # got pt (19419/17801, 11629/24865)
+        sage: all(l(pt) < 0 for l in ineqs) and ineq(pt)>0
+        True
     """
     # heuristic method.
     ineq_gradient = gradient(ineq)
     current_point = vector(RR(x) for x in current_var_value) # Real numbers, faster than QQ
     ineq_value = ineq(*current_point)
-    try_before_fail =  min(ceil(2/flip_ineq_step), 2000)  # define maximum number of walks.
+    try_before_fail =  max(ceil(2/flip_ineq_step), 2000)  # define maximum number of walks.
     while (ineq_value <= 1e-10) and (try_before_fail > 0):
         ineq_direction = vector(g(*current_point) for g in ineq_gradient)
         if ineq.degree() == 1:

--- a/cutgeneratingfunctionology/igp/parametric.sage
+++ b/cutgeneratingfunctionology/igp/parametric.sage
@@ -86,7 +86,7 @@ class ParametricRealField(Field):
         sage: K.get_eq_factor()
         set()
         sage: K.get_lt_factor()
-        {-f, -f + 1/2, f - 1}
+        {-2*f + 1, -f, f - 1}
 
         sage: K.<f, lam> = ParametricRealField([4/5, 1/6])
         sage: h = gj_2_slope(f, lam, field=K)
@@ -117,7 +117,7 @@ class ParametricRealField(Field):
         sage: extremality_test(h)
         True
         sage: K.get_lt_factor()
-        {-f, f - 1, f - 1/2, f - 1/3}
+        {-f, f - 1, 2*f - 1, 3*f - 1}
 
     Elements coerce to RDF, RR, float to enable plotting of functions::
 
@@ -861,7 +861,9 @@ class ParametricRealField(Field):
             numerator = comparison.numerator()
             # We use two different normalizations for the univariate and the multivariate case,
             # just to match the behavior of factor() for the doctests.
-            if self.ngens() == 1:
+            # if self.ngens() == 1 can't distinguish between the two, as we know use sym_ring = PolynomialRing(QQ, names, len(names)).
+            from sage.rings.polynomial.polynomial_ring import is_PolynomialRing
+            if is_PolynomialRing(self._sym_field.ring()):
                 unit = abs(comparison.numerator().lc())
             else:
                 the_lcm = lcm([coeff.denominator() for coeff in numerator.coefficients()])
@@ -2537,7 +2539,7 @@ def find_region_type_igp(K, h, region_level='extreme', is_minimal=None):
         sage: find_region_type_igp(K, h)
         'is_extreme'
         sage: K.get_lt_factor()
-        {-f, -f + 1/2, f - 1}
+        {-2*f + 1, -f, f - 1}
 
         sage: K.<f,bkpt>=ParametricRealField([1/7,3/7])
         sage: h = drlm_backward_3_slope(f, bkpt, field=K)
@@ -3213,7 +3215,7 @@ EXAMPLES::
     sage: h = gmic(f, field=K)
     sage: _ = extremality_test(h)
     sage: sorted(K.get_eq_factor()), sorted(K.get_lt_factor()), sorted(K.get_le_factor())
-    ([], [-f, -f + 1/2, f - 1], [])
+    ([], [-2*f + 1, -f, f - 1], [])
     sage: sorted(K._bsa.eq_poly()), sorted(K._bsa.lt_poly()), sorted(K._bsa.le_poly())
     ([], [-2*f + 1, f - 1], [])
 

--- a/cutgeneratingfunctionology/igp/parametric_cpl.sage
+++ b/cutgeneratingfunctionology/igp/parametric_cpl.sage
@@ -260,7 +260,7 @@ def coefficients_of_theta_and_rhs_in_constraint(c, var_name, n):
     """
     # assume c.parent() is Fraction Field of Multivariate Polynomial Ring in var_names and (n-1) theta variables over Rational Field.
     # assume c is linear over the (n-1) theta variables.
-    P = PolynomialRing(QQ, var_name)
+    P = PolynomialRing(QQ, var_name, len(var_name))
     P1 = P.one(); P0 = P.zero()
     cn = c.numerator()
     var_sym = list(P.gens()) + [P0] * (n - 1)

--- a/cutgeneratingfunctionology/igp/vertex_enumeration.py
+++ b/cutgeneratingfunctionology/igp/vertex_enumeration.py
@@ -448,7 +448,11 @@ def lrs_lrs(in_str, verbose=False):
     if verbose: print(in_str)
 
     redund_procs = Popen(['lrs',in_filename],stdin = PIPE, stdout=PIPE, stderr=PIPE)
-    out_str, err = redund_procs.communicate()
+    out_bytes, err = redund_procs.communicate()
+    out_str = out_bytes.decode("utf-8") # lrslib changed, output is of type bytes
+    if verbose:
+        print(out_str)
+    return out_str
     if verbose:
         print(out_str)
     return out_str

--- a/cutgeneratingfunctionology/spam/basic_semialgebraic_linear_system.py
+++ b/cutgeneratingfunctionology/spam/basic_semialgebraic_linear_system.py
@@ -181,13 +181,13 @@ class BasicSemialgebraicSet_polyhedral_linear_system(BasicSemialgebraicSet_polyh
         ``BasicSemialgebraicSet_polyhedral_linear_system``.
         """
         # create a new poly_ring with one less generator (coordinate).
-        if coordinate_index>=self._poly_ring.ngens():
+        if coordinate_index >= self._poly_ring.ngens():
             raise ValueError("doesn't exist the elimination variable")
-        coordinate=self._poly_ring.gens()[coordinate_index]
-        variables_names=[str(self._poly_ring.gens()[i]) for i in range(self._poly_ring.ngens()) if i != coordinate_index]
-        new_poly_ring=PolynomialRing(self._base_ring,variables_names)
+        coordinate = self._poly_ring.gens()[coordinate_index]
+        variables_names = [str(self._poly_ring.gens()[i]) for i in range(self._poly_ring.ngens()) if i != coordinate_index]
+        new_poly_ring = PolynomialRing(self._base_ring, variables_names, len(variables_names))
         # create the ring hommorphism
-        polynomial_map=[new_poly_ring.gens()[i] for i in range(new_poly_ring.ngens())]
+        polynomial_map = [new_poly_ring.gens()[i] for i in range(new_poly_ring.ngens())]
         polynomial_map.insert(coordinate_index,new_poly_ring(0))
         
         new_eq=[]

--- a/cutgeneratingfunctionology/spam/parametric_real_field_element.py
+++ b/cutgeneratingfunctionology/spam/parametric_real_field_element.py
@@ -56,9 +56,11 @@ class ParametricRealFieldElement(FieldElement):
             ## Test coercing the value to RR, so that we do not try to build a ParametricRealFieldElement
             ## from something like a tuple or vector or list or variable of a polynomial ring
             ## or something else that does not make any sense.
-            from sage.interfaces.mathematica import MathematicaElement
-            if not isinstance(value, MathematicaElement):
-                RR(value)
+            print(parent(value))
+            import pdb
+            pdb.set_trace()
+            if not RR.has_coerce_map_from(parent(value)):
+                raise TypeError("Value is of wrong type")
             self._val = value
         if symbolic is None:
             self._sym = value # changed to not coerce into SR. -mkoeppe

--- a/cutgeneratingfunctionology/spam/parametric_real_field_element.py
+++ b/cutgeneratingfunctionology/spam/parametric_real_field_element.py
@@ -57,8 +57,13 @@ class ParametricRealFieldElement(FieldElement):
             ## from something like a tuple or vector or list or variable of a polynomial ring
             ## or something else that does not make any sense.
             # FIXME: parent(value) caused SIGSEGV because of an infinite recursion
-            if not ((type(value) is int) or hasattr(value, 'parent') and RR.has_coerce_map_from(value.parent())):
-                raise TypeError("Value is of wrong type")
+            from sage.structure.coerce import py_scalar_parent
+            if hasattr(value, 'parent'):
+                if not RR.has_coerce_map_from(value.parent()):
+                    raise TypeError("Value is of wrong type")
+            else:
+                if not RR.has_coerce_map_from(py_scalar_parent(type(value))):
+                    raise TypeError("Value is of wrong type")
             self._val = value
         if symbolic is None:
             self._sym = value # changed to not coerce into SR. -mkoeppe

--- a/cutgeneratingfunctionology/spam/parametric_real_field_element.py
+++ b/cutgeneratingfunctionology/spam/parametric_real_field_element.py
@@ -57,7 +57,7 @@ class ParametricRealFieldElement(FieldElement):
             ## from something like a tuple or vector or list or variable of a polynomial ring
             ## or something else that does not make any sense.
             # FIXME: parent(value) caused SIGSEGV because of an infinite recursion
-            if (not type(value) is int) and (not RR.has_coerce_map_from(value.parent())):
+            if not ((type(value) is int) or hasattr(value, 'parent') and RR.has_coerce_map_from(value.parent())):
                 raise TypeError("Value is of wrong type")
             self._val = value
         if symbolic is None:

--- a/cutgeneratingfunctionology/spam/parametric_real_field_element.py
+++ b/cutgeneratingfunctionology/spam/parametric_real_field_element.py
@@ -56,10 +56,8 @@ class ParametricRealFieldElement(FieldElement):
             ## Test coercing the value to RR, so that we do not try to build a ParametricRealFieldElement
             ## from something like a tuple or vector or list or variable of a polynomial ring
             ## or something else that does not make any sense.
-            print(parent(value))
-            import pdb
-            pdb.set_trace()
-            if not RR.has_coerce_map_from(parent(value)):
+            # FIXME: parent(value) caused SIGSEGV because of an infinite recursion
+            if (not type(value) is int) and (not RR.has_coerce_map_from(value.parent())):
                 raise TypeError("Value is of wrong type")
             self._val = value
         if symbolic is None:


### PR DESCRIPTION
Call the `PolynomialRing` factory function in a way that ensures multivariate polynomial rings are created even when there is only a single variable. This is a workaround for the inconsistent/incomplete API of univariate polynomial rings in Sage.

Some doctests are adjusted to account for the different sorting order of elements after this change.

Also, a py3 fix for use of lrslib.